### PR TITLE
Add support for C# and TypeScript

### DIFF
--- a/Plugins/src_VCPP/IgnoreCommentsC/WinMergeScript.cpp
+++ b/Plugins/src_VCPP/IgnoreCommentsC/WinMergeScript.cpp
@@ -22,7 +22,7 @@ STDMETHODIMP CWinMergeScript::get_PluginDescription(BSTR *pVal)
 
 STDMETHODIMP CWinMergeScript::get_PluginFileFilters(BSTR *pVal)
 {
-  *pVal = SysAllocString(L"\\.cpp$;\\.cxx$;\\.h$;\\.hxx$;\\.c$;\\.php$;\\.js$");
+  *pVal = SysAllocString(L"\\.cpp$;\\.cxx$;\\.h$;\\.hxx$;\\.c$;\\.php$;\\.js$;\\.cs$;\\.ts$");
   return S_OK;
 }
 


### PR DESCRIPTION
Add two file extensions to the Ignore comments plugin to support C Sharp and TypeScript.